### PR TITLE
Bump `ghostwriter/coding-standard` to `dev-main#f46c564`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2991,12 +2991,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "74310bf3f96a3a24ce2cd57449737cc9d9f8f18a"
+                "reference": "f46c5647930fbef9b2efe04bce978a6713eace5a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/74310bf3f96a3a24ce2cd57449737cc9d9f8f18a",
-                "reference": "74310bf3f96a3a24ce2cd57449737cc9d9f8f18a",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/f46c5647930fbef9b2efe04bce978a6713eace5a",
+                "reference": "f46c5647930fbef9b2efe04bce978a6713eace5a",
                 "shasum": ""
             },
             "require": {
@@ -3046,7 +3046,7 @@
                 "ext-xdebug": "*",
                 "mockery/mockery": "~1.6.12",
                 "nikic/php-parser": "~5.6.1",
-                "phpunit/phpunit": "~12.3.9",
+                "phpunit/phpunit": "~12.3.10",
                 "symfony/var-dumper": "~7.3.3"
             },
             "default-branch": true,
@@ -3153,7 +3153,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-11T07:14:05+00:00"
+            "time": "2025-09-11T11:25:50+00:00"
         },
         {
             "name": "ghostwriter/option",


### PR DESCRIPTION
Bumps `ghostwriter/coding-standard` from `dev-main#74310bf` to `dev-main#f46c564`.

This pull request changes the following file(s): 

- Update `composer.lock`