### PR TITLE
Update ghostwriter/coding-standard to version dev-main#59d102d

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2991,12 +2991,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "0347d434a01e9215a2f1dee4d1e4b651e6f96fa3"
+                "reference": "59d102de258c5fa6b88d1670929c9c99702b2029"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/0347d434a01e9215a2f1dee4d1e4b651e6f96fa3",
-                "reference": "0347d434a01e9215a2f1dee4d1e4b651e6f96fa3",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/59d102de258c5fa6b88d1670929c9c99702b2029",
+                "reference": "59d102de258c5fa6b88d1670929c9c99702b2029",
                 "shasum": ""
             },
             "require": {
@@ -3046,7 +3046,7 @@
                 "ext-xdebug": "*",
                 "mockery/mockery": "^1.6.12",
                 "nikic/php-parser": "^5.6.1",
-                "phpunit/phpunit": "^12.3.14",
+                "phpunit/phpunit": "^12.3.15",
                 "symfony/var-dumper": "^7.3.4"
             },
             "default-branch": true,
@@ -3153,7 +3153,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-27T13:40:07+00:00"
+            "time": "2025-09-28T14:05:58+00:00"
         },
         {
             "name": "ghostwriter/option",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#0347d43` to `dev-main#59d102d`.

This pull request changes the following file(s): 

- Update `composer.lock`