### PR TITLE
Update ghostwriter/coding-standard to version dev-main#d58158d

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2991,12 +2991,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "be1ff185427b5f9faa61ff36fcf9743711f22c6f"
+                "reference": "d58158d2d2683050a060dc270fc39975fa6f5f04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/be1ff185427b5f9faa61ff36fcf9743711f22c6f",
-                "reference": "be1ff185427b5f9faa61ff36fcf9743711f22c6f",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/d58158d2d2683050a060dc270fc39975fa6f5f04",
+                "reference": "d58158d2d2683050a060dc270fc39975fa6f5f04",
                 "shasum": ""
             },
             "require": {
@@ -3046,7 +3046,7 @@
                 "ext-xdebug": "*",
                 "mockery/mockery": "^1.6.12",
                 "nikic/php-parser": "^5.6.1",
-                "phpunit/phpunit": "^12.3.15",
+                "phpunit/phpunit": "^12.4.1",
                 "symfony/var-dumper": "^7.3.4"
             },
             "default-branch": true,
@@ -3153,7 +3153,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-30T15:45:10+00:00"
+            "time": "2025-10-11T22:51:37+00:00"
         },
         {
             "name": "ghostwriter/option",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#be1ff18` to `dev-main#d58158d`.

This pull request changes the following file(s): 

- Update `composer.lock`