### PR TITLE
Update nikic/php-parser to version 5.6.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "ghostwriter/json": "^3.0.0",
         "ghostwriter/shell": "^0.1.0",
         "ghostwriter/uuid": "^1.0.3",
-        "nikic/php-parser": "^5.6.1",
+        "nikic/php-parser": "^5.6.2",
         "sebastian/diff": "^7.0.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "73981f9ccfabc5a4669832b9490b936c",
+    "content-hash": "7b74e0cef3fc6a93da118405c72839da",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1390,16 +1390,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.6.1",
+            "version": "v5.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
+                "reference": "3a454ca033b9e06b63282ce19562e892747449bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/3a454ca033b9e06b63282ce19562e892747449bb",
+                "reference": "3a454ca033b9e06b63282ce19562e892747449bb",
                 "shasum": ""
             },
             "require": {
@@ -1442,9 +1442,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.2"
             },
-            "time": "2025-08-13T20:13:15+00:00"
+            "time": "2025-10-21T19:32:17+00:00"
         },
         {
             "name": "psr/container",


### PR DESCRIPTION
Updates the `nikic/php-parser` dependency from `v5.6.1` to `5.6.2`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`