### PR TITLE
Update ghostwriter/config to version 2.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "ghostwriter/case-converter": "^2.2.0",
         "ghostwriter/clock": "^3.0.1",
         "ghostwriter/collection": "^2.0.0",
-        "ghostwriter/config": "^2.0.0",
+        "ghostwriter/config": "^2.0.1",
         "ghostwriter/container": "^5.0.1",
         "ghostwriter/event-dispatcher": "^5.0.3",
         "ghostwriter/filesystem": "^0.1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d6f1cf650bda07262d614b2b79a6834d",
+    "content-hash": "ddb78c3a9d2e21043c9da4a650fccdcf",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -835,16 +835,16 @@
         },
         {
             "name": "ghostwriter/config",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/config.git",
-                "reference": "502d899651159db1178448eb7dec44320fe2aa15"
+                "reference": "97b0423aaed59c848a163ab10db5b0697a6d76d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/config/zipball/502d899651159db1178448eb7dec44320fe2aa15",
-                "reference": "502d899651159db1178448eb7dec44320fe2aa15",
+                "url": "https://api.github.com/repos/ghostwriter/config/zipball/97b0423aaed59c848a163ab10db5b0697a6d76d2",
+                "reference": "97b0423aaed59c848a163ab10db5b0697a6d76d2",
                 "shasum": ""
             },
             "require": {
@@ -853,11 +853,19 @@
             "require-dev": {
                 "ext-xdebug": "*",
                 "ghostwriter/coding-standard": "dev-main",
+                "ghostwriter/container": "^6.0.1",
                 "mockery/mockery": "^1.6.12",
-                "phpunit/phpunit": "^12.4.2",
+                "phpunit/phpunit": "^12.4.3",
                 "symfony/var-dumper": "^7.3.5"
             },
             "type": "library",
+            "extra": {
+                "ghostwriter": {
+                    "container": {
+                        "definition": "Ghostwriter\\Config\\Container\\ConfigurationDefinition"
+                    }
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Ghostwriter\\Config\\": "src/"
@@ -893,7 +901,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-01T18:10:07+00:00"
+            "time": "2025-11-19T09:00:09+00:00"
         },
         {
             "name": "ghostwriter/container",


### PR DESCRIPTION
Updates the `ghostwriter/config` dependency from `2.0.0` to `2.0.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`