### PR TITLE
Update ghostwriter/filesystem to version 0.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "ghostwriter/config": "^2.1.1",
         "ghostwriter/container": "^6.1.1",
         "ghostwriter/event-dispatcher": "^6.1.0",
-        "ghostwriter/filesystem": "^0.1.2",
+        "ghostwriter/filesystem": "^0.2.0",
         "ghostwriter/json": "^3.0.2",
         "ghostwriter/shell": "^0.1.5",
         "ghostwriter/uuid": "^1.0.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6f01b0a7ee049a1f5ac36984649f4600",
+    "content-hash": "52be1aa7342081c473155730afcc6c42",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1082,16 +1082,16 @@
         },
         {
             "name": "ghostwriter/filesystem",
-            "version": "0.1.2",
+            "version": "0.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/filesystem.git",
-                "reference": "49caa2d2adfdf01afb5db347355bf3fb5efde704"
+                "reference": "5f4cf2cdb8c71523ff3d79402d23d05fd12d4979"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/filesystem/zipball/49caa2d2adfdf01afb5db347355bf3fb5efde704",
-                "reference": "49caa2d2adfdf01afb5db347355bf3fb5efde704",
+                "url": "https://api.github.com/repos/ghostwriter/filesystem/zipball/5f4cf2cdb8c71523ff3d79402d23d05fd12d4979",
+                "reference": "5f4cf2cdb8c71523ff3d79402d23d05fd12d4979",
                 "shasum": ""
             },
             "require": {
@@ -1100,16 +1100,22 @@
             "require-dev": {
                 "ext-xdebug": "*",
                 "ghostwriter/coding-standard": "dev-main",
-                "ghostwriter/container": "^6.0.1",
+                "ghostwriter/container": "^6.1.1",
                 "mockery/mockery": "^1.6.12",
-                "phpunit/phpunit": "^12.4.3",
-                "symfony/var-dumper": "^7.3.5"
+                "phpunit/phpunit": "^13.1.3",
+                "symfony/var-dumper": "^8.0.8"
             },
             "type": "library",
             "extra": {
+                "thanks": {
+                    "url": "https://github.com/ghostwriter/filesystem",
+                    "name": "ghostwriter/filesystem"
+                },
                 "ghostwriter": {
                     "container": {
-                        "definition": "Ghostwriter\\Filesystem\\Container\\FilesystemDefinition"
+                        "provider": [
+                            "Ghostwriter\\Filesystem\\Container\\FilesystemProvider"
+                        ]
                     }
                 }
             },
@@ -1120,7 +1126,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-4-Clause"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
@@ -1148,7 +1154,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-21T06:25:48+00:00"
+            "time": "2026-04-14T15:21:54+00:00"
         },
         {
             "name": "ghostwriter/json",


### PR DESCRIPTION
Updates the `ghostwriter/filesystem` dependency from `0.1.2` to `0.2.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`