### PR TITLE
Update boundwize/structarmed to version 0.5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.5.2",
+        "boundwize/structarmed": "^0.5.3",
         "ghostwriter/coding-standard": "dev-main",
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^13.1.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d41b36081b43dcbec0129f61b727ed38",
+    "content-hash": "0a7b596321d873b3b4d40f8051446ce7",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -3333,16 +3333,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.5.2",
+            "version": "0.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "f37234c3c1b7ba74ac7b2174c7dcabbb509b9a5e"
+                "reference": "7b1b4b617f56430321359c4c86ddeba75de52981"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/f37234c3c1b7ba74ac7b2174c7dcabbb509b9a5e",
-                "reference": "f37234c3c1b7ba74ac7b2174c7dcabbb509b9a5e",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/7b1b4b617f56430321359c4c86ddeba75de52981",
+                "reference": "7b1b4b617f56430321359c4c86ddeba75de52981",
                 "shasum": ""
             },
             "require": {
@@ -3391,7 +3391,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.5.2"
+                "source": "https://github.com/boundwize/structarmed/tree/0.5.3"
             },
             "funding": [
                 {
@@ -3399,7 +3399,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-14T04:43:27+00:00"
+            "time": "2026-05-14T13:26:14+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.5.2` to `0.5.3`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`