### PR TITLE
Update boundwize/structarmed to version 0.5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.5.3",
+        "boundwize/structarmed": "^0.5.4",
         "ghostwriter/coding-standard": "dev-main",
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^13.1.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0a7b596321d873b3b4d40f8051446ce7",
+    "content-hash": "f32eac60a46502d688b2885dcbb4dba8",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -3333,16 +3333,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.5.3",
+            "version": "0.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "7b1b4b617f56430321359c4c86ddeba75de52981"
+                "reference": "1b75ee70748fb570aa9241de334139f08544e0fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/7b1b4b617f56430321359c4c86ddeba75de52981",
-                "reference": "7b1b4b617f56430321359c4c86ddeba75de52981",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/1b75ee70748fb570aa9241de334139f08544e0fe",
+                "reference": "1b75ee70748fb570aa9241de334139f08544e0fe",
                 "shasum": ""
             },
             "require": {
@@ -3391,7 +3391,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.5.3"
+                "source": "https://github.com/boundwize/structarmed/tree/0.5.4"
             },
             "funding": [
                 {
@@ -3399,7 +3399,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-14T13:26:14+00:00"
+            "time": "2026-05-14T14:37:07+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -3468,16 +3468,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "b7dce2470724cd286a8ba640eeae6808bba59059"
+                "reference": "4eb34164b3d6f5a5bc81a01e00d291360ccfba41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/b7dce2470724cd286a8ba640eeae6808bba59059",
-                "reference": "b7dce2470724cd286a8ba640eeae6808bba59059",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/4eb34164b3d6f5a5bc81a01e00d291360ccfba41",
+                "reference": "4eb34164b3d6f5a5bc81a01e00d291360ccfba41",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.5.2",
+                "boundwize/structarmed": "^0.5.4",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -3588,7 +3588,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-14T06:45:27+00:00"
+            "time": "2026-05-14T15:46:14+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.5.3` to `0.5.4`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`