### PR TITLE
Update boundwize/structarmed to version 0.6.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.6.9",
+        "boundwize/structarmed": "^0.6.13",
         "ghostwriter/coding-standard": "dev-main",
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^13.1.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea65b15571362bacd1843e1b409db52a",
+    "content-hash": "f982547b76b3bfba8657406f3a97078c",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -3337,16 +3337,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.6.9",
+            "version": "0.6.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "3c2f00553b55c98de1966d75d914ea27a35bcf7a"
+                "reference": "7a6e3a9e4b8e7ae6cb344c5933240a8d71dd62bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/3c2f00553b55c98de1966d75d914ea27a35bcf7a",
-                "reference": "3c2f00553b55c98de1966d75d914ea27a35bcf7a",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/7a6e3a9e4b8e7ae6cb344c5933240a8d71dd62bc",
+                "reference": "7a6e3a9e4b8e7ae6cb344c5933240a8d71dd62bc",
                 "shasum": ""
             },
             "require": {
@@ -3395,7 +3395,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.6.9"
+                "source": "https://github.com/boundwize/structarmed/tree/0.6.13"
             },
             "funding": [
                 {
@@ -3403,7 +3403,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-19T08:16:03+00:00"
+            "time": "2026-05-19T15:51:33+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -3472,16 +3472,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "7cd775e1b9f3bcf6c31712bd6e7597123147a674"
+                "reference": "1edf464ea9689e52d936975bbf61f76e38a2d416"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/7cd775e1b9f3bcf6c31712bd6e7597123147a674",
-                "reference": "7cd775e1b9f3bcf6c31712bd6e7597123147a674",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/1edf464ea9689e52d936975bbf61f76e38a2d416",
+                "reference": "1edf464ea9689e52d936975bbf61f76e38a2d416",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.6.9",
+                "boundwize/structarmed": "^0.6.13",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -3592,7 +3592,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-19T08:49:35+00:00"
+            "time": "2026-05-19T20:24:27+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.6.9` to `0.6.13`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`