### PR TITLE
Update `ghostwriter/event-dispatcher` to version `6.1.3`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "ghostwriter/config": "^2.1.3",
         "ghostwriter/console": "^0.2.3",
         "ghostwriter/container": "^7.0.2",
-        "ghostwriter/event-dispatcher": "^6.1.2",
+        "ghostwriter/event-dispatcher": "^6.1.3",
         "ghostwriter/filesystem": "^0.2.0",
         "ghostwriter/json": "^3.0.2",
         "ghostwriter/shell": "^0.1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "04572dbad858f2ee8fe878f242278e8a",
+    "content-hash": "11278679a58d17cd56e964e2ec9c504b",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1103,16 +1103,16 @@
         },
         {
             "name": "ghostwriter/event-dispatcher",
-            "version": "6.1.2",
+            "version": "6.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/event-dispatcher.git",
-                "reference": "617c1ee6cd63407ad9f9932e4a2833fb226f574e"
+                "reference": "f09567008800086371068ff52d6ca418aeabbca8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/event-dispatcher/zipball/617c1ee6cd63407ad9f9932e4a2833fb226f574e",
-                "reference": "617c1ee6cd63407ad9f9932e4a2833fb226f574e",
+                "url": "https://api.github.com/repos/ghostwriter/event-dispatcher/zipball/f09567008800086371068ff52d6ca418aeabbca8",
+                "reference": "f09567008800086371068ff52d6ca418aeabbca8",
                 "shasum": ""
             },
             "require": {
@@ -1183,7 +1183,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-29T20:47:09+00:00"
+            "time": "2026-05-29T22:38:50+00:00"
         },
         {
             "name": "ghostwriter/filesystem",


### PR DESCRIPTION
Updates the [`ghostwriter/event-dispatcher`](https://packagist.org/packages/ghostwriter/event-dispatcher) dependency from `6.1.2` to `6.1.3`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`